### PR TITLE
use dest as a passthrough

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,34 +1,18 @@
 const gulp = require('gulp');
 const gulpBabel = require('gulp-babel');
-const gulpClone = require('gulp-clone');
 const gulpGzip = require('gulp-gzip');
 const pump = require('pump');
-const merge2 = require('merge2');
-
-const sourcemapWrite = require('vinyl-fs/lib/dest/sourcemap');
 
 gulp.task('default', () => {
-	const stream = pump(
+	// I'd highly recommend using `require('stream').pipeline`
+	// because pump doesn't error correctly on the returned stream
+	return pump(
 		gulp.src('src/**', {sourcemaps: true}),
 		gulpBabel({
 			presets: ['minify']
 		}),
-		sourcemapWrite({
-			resolve: () => '.'
-		})
-	);
-
-	const merged = merge2(
-		stream,
-		pump(
-			stream,
-			gulpClone(),
-			gulpGzip()
-		)
-	);
-
-	return pump(
-		merged,
-		gulp.dest('wwwroot')
+		gulp.dest('wwwroot', { sourcemaps: '.' }),
+		gulpGzip(),
+		gulp.dest('wwwroot'),
 	);
 });


### PR DESCRIPTION
the `gulp.dest()` stream can be used as a passthrough, which allows for "phased" builds.  Not many people know of this feature (I really need to find more time to write about these things), but I spent a ton of time making sure it works correctly for gulp 4.

I made a commit that contained the output files and then re-ran gulp with these changes and the output was exactly the same, so I believe this achieves your same goals.